### PR TITLE
Adds starter style ref - colors

### DIFF
--- a/src/style-ref.css
+++ b/src/style-ref.css
@@ -1,0 +1,17 @@
+/* references for styling for app */
+
+/* HEX CODES */
+
+/* PALETTE REF */
+
+/*
+  https://www.color-hex.com/color-palette/1217
+
+  #dc6900 - burnt orange
+  #eb8c00 - beer gold
+  #e0301e - bright red (or true)
+  #a32020 - darker red
+  #602320 - dark maroon
+*/
+
+ /* If we use Google Font: */


### PR DESCRIPTION
This adds a style reference for color palette for the app.

#### Only adds:
CSS reference file for future ref. No font imports or anything else added yet. 