### PR TITLE
Importing Fontawesome & added about cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "brew-pulse",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.4.2",
+        "@fortawesome/free-brands-svg-icons": "^6.4.2",
+        "@fortawesome/free-solid-svg-icons": "^6.4.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2366,6 +2370,63 @@
       "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
+      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
+      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-LKOwJX0I7+mR/cvvf6qIiqcERbdnY+24zgpUSouySml+5w8B4BJOx8EhDR/FTKAu06W12fmUIcv6lzPSwYKGGg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.2",
+    "@fortawesome/free-brands-svg-icons": "^6.4.2",
+    "@fortawesome/free-solid-svg-icons": "^6.4.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/About.css
+++ b/src/About.css
@@ -1,0 +1,50 @@
+.card img {
+  width: 80%;
+  border-radius: 50%;
+  margin: 0 auto;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.card .card-title {
+  font-weight: 700;
+  font-size: 1.5em;
+}
+
+.card .btn {
+  border-radius: 2em;
+  background-color: #602320 !important;
+  color: #ffffff;
+  padding: 0.5em 1.5em;
+  transform: scale(1);
+}
+
+.card .btn:hover {
+  background-color: #a32020 !important;
+  color: #ffffff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  transform: scale(1.01);
+}
+
+.card {
+  transition: transform 0.3s ease;
+  transform: scale(1);
+}
+
+.card:hover {
+  /* Scale the card up by 5% when hovered */
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2) !important;
+  transform: scale(1.05);
+}
+
+.github {
+    margin-right: 5px;
+}
+
+
+
+/* body .background {
+    background-image: url('./bg.png');
+    height: 100vh;
+    background-size: cover;
+    background-repeat: no-repeat;
+} */

--- a/src/About.js
+++ b/src/About.js
@@ -1,7 +1,95 @@
 import React from "react";
+import Card from "react-bootstrap/Card";
+import Button from "react-bootstrap/Button";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons";
+import "./About.css";
 
 function About() {
-  return <div>About us page</div>;
+  const cardDetails = [
+    {
+      name: "Vanessa Jesik",
+      imageUrl:
+        "https://www.usnews.com/dims4/USNEWS/af66e3c/2147483647/crop/2000x1313+0+0/resize/640x420/quality/85/?url=https%3A%2F%2Fwww.usnews.com%2Fcmsmedia%2Ff9%2Ff1%2Fa6174c87479b8222c09903d7651c%2F190219-softwaredevelopers-stock.jpg",
+      description: "Some quick example text for the first card. This is more about me!",
+      buttonLink: "#",
+      githubLink: "https://github.com/vanessa-jesik",
+      linkedinLink: "https://linkedin.com/in/vanessa-jesik",
+    },
+    {
+      name: "Rae Stanton",
+      imageUrl:
+        "https://www.usnews.com/dims4/USNEWS/af66e3c/2147483647/crop/2000x1313+0+0/resize/640x420/quality/85/?url=https%3A%2F%2Fwww.usnews.com%2Fcmsmedia%2Ff9%2Ff1%2Fa6174c87479b8222c09903d7651c%2F190219-softwaredevelopers-stock.jpg",
+      description: "Some quick example text for the second card. This is more about me!",
+      buttonLink: "#",
+      githubLink: "https://github.com/rae-stanton",
+      linkedinLink: "https://linkedin.com/in/rae-stanton",
+    },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-around",
+        padding: "2em",
+      }}
+    >
+      {cardDetails.map((card, index) => (
+        <Card
+          key={index}
+          style={{
+            width: "30rem",
+            marginTop: "2em",
+            padding: "2em 1em 1em",
+            borderRadius: "2em",
+            textAlign: "center",
+            boxShadow: "0 5px 10px rgba(0, 0, 0, 0.2)",
+          }}
+        >
+          <Card.Img
+            variant="top"
+            src={card.imageUrl}
+            style={{
+              width: "65%",
+              borderRadius: "50%",
+              margin: "0 auto",
+              boxShadow: "0 0 10px rgba(0, 0, 0, 0.2)",
+            }}
+            alt={card.name}
+          />
+          <Card.Body>
+            <Button href={card.githubLink} target="_blank" className="github">
+              <FontAwesomeIcon icon={faGithub} />
+            </Button>
+            <Button
+              href={card.linkedinLink}
+              target="_blank"
+              className="linkedin"
+            >
+              <FontAwesomeIcon icon={faLinkedin} />
+            </Button>
+
+            <Card.Title style={{ fontWeight: 700, fontSize: "1.5em" }}>
+              {card.name}
+            </Card.Title>
+            <Card.Text>{card.description}</Card.Text>
+
+            <Button
+              style={{
+                borderRadius: "2em",
+                color: "#ffffff",
+                padding: "0.5em 1.5em",
+              }}
+              href={card.buttonLink}
+            >
+              Learn More
+            </Button>
+          </Card.Body>
+        </Card>
+      ))}
+    </div>
+  );
 }
 
 export default About;


### PR DESCRIPTION
### Changes
This is part one of our about us section - see more will eventually be to wire up populating our city's closest breweries. This needs to have actual photos of us and make sure our GitHub & Linked In links are correct. 

### Screenshot
<img width="1432" alt="Screenshot 2023-09-05 at 7 14 28 PM" src="https://github.com/vajesik/brew-pulse/assets/101673900/1c805655-89e9-48e9-bc66-c4a46a1cfe11">

### Styling
The cards here have slightly different styling from the other cards in the app - I wanted them to feel a little different! This also added an `About.css` file to reflect some styling that wasn't done inline - I may want to refactor this so all of the styling possible is done within the CSS to clean up the About component a little more. Until then, it's a good start.

### Other
With importing FontAwesome, you'll need to run `npm install` again to make sure you don't get errors. If you wanna start using some of their icons, you are now able to! They have a decent selection of free ones we can import throughout the app.
[https://fontawesome.com/start](url)